### PR TITLE
fix: correct OpenSSF Scorecard action SHA pin

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run Scorecard"
-        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca94b1 # v2.4.2
+        uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary

- Fix incorrect commit SHA for `ossf/scorecard-action@v2.4.2`
- Previous pin `...ca94b1` did not resolve; correct pin is `...ca8cde`

## Test plan

- [ ] Scorecard workflow resolves the action and runs successfully