### PR TITLE
ci: exclude iso.org from link check

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -43,6 +43,7 @@ jobs:
           --exclude 'docs.github.com'
           --exclude 'c2pa.org'
           --exclude 'doi.org'
+          --exclude 'iso.org'
           --exclude 'writerslogic'
           --exclude 'cawg.io'
           --exclude 'sagaftra.org'


### PR DESCRIPTION
iso.org returns 403 to the lychee user-agent, failing Check Links on every PR that touches docs (most recently #97 and #93, neither of which touched the offending file docs/conformance/iso42001.md). Adds iso.org to the existing exclude list alongside doi.org and the other publisher domains that block automated checkers.