### PR TITLE
fix(ci): repair Lifecycle Status workflow; align HAT draft metadata

### DIFF
--- a/.github/workflows/lifecycle.yml
+++ b/.github/workflows/lifecycle.yml
@@ -95,10 +95,12 @@ jobs:
             replacement=$(printf '%s\n%s %s\n  - Current: %s\n%s' \
               "$open" "$checkbox" "$label" "$detail" "$close")
 
-            # Use awk to replace between markers
-            awk -v open="$open" -v close="$close" -v repl="$replacement" '
+            # Use awk to replace between markers.
+            # NOTE: 'close' is a gawk builtin and is rejected as a -v variable
+            # name (fatal error), so pass the end marker as 'endm' instead.
+            awk -v open="$open" -v endm="$close" -v repl="$replacement" '
               $0 ~ open { skip=1; print repl; next }
-              $0 ~ close { skip=0; next }
+              $0 ~ endm { skip=0; next }
               !skip { print }
             ' "$FILE" > "${FILE}.tmp" && mv "${FILE}.tmp" "$FILE"
           }

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *~
 .tags
 /*-[0-9][0-9].xml
+/draft-*.xml
 /.*.mk
 /.gems/
 /.refcache

--- a/cddl/hat.cddl
+++ b/cddl/hat.cddl
@@ -1,7 +1,7 @@
 ; SPDX-License-Identifier: Apache-2.0
 ;
 ; Hardware Attestation of Time (HAT) -- Standalone CDDL
-; Canonical definition for draft-condrey-rats-hat
+; Canonical definition for draft-condrey-hat
 ;
 ; This file contains the HAT-specific subset of the CPoE CDDL schema.
 ; The parent schema (cpoe.cddl) embeds this definition in the

--- a/draft-condrey-hat.md
+++ b/draft-condrey-hat.md
@@ -1,7 +1,7 @@
 ---
 v: 3
 docname: draft-condrey-hat-latest
-date: 2026-05
+date: 2026-06-17
 title: "Hardware Attestation of Time (HAT): TPM-Based Temporal Binding for Remote Attestation"
 abbrev: HAT
 category: info


### PR DESCRIPTION
Two small maintenance changes.

The Lifecycle Status workflow has failed on every run since 2026-06-12. Root cause is a gawk fatal in the update_section helper: it passed the end marker via awk -v close=..., and close is a gawk builtin that cannot be used as a variable name (gawk: fatal: cannot use gawk builtin 'close' as variable name). The marker is now passed as endm. Reproduced and verified against GNU Awk 5.4.0: the old form exits 2 with that fatal, the new form exits 0 and replaces the marked section correctly. This is unrelated to the recent actions/checkout v7 bump, which merged cleanly.

The HAT draft changes align the canonical CDDL reference from draft-condrey-rats-hat to draft-condrey-hat so it matches the .md docname, bump the draft date to 2026-06-17, and add /draft-*.xml to .gitignore since the draft .xml files are generated build artifacts (no .xml is tracked in the repo).