### PR TITLE
docs: correct unverified lifecycle and roadmap status claims

### DIFF
--- a/LIFECYCLE.md
+++ b/LIFECYCLE.md
@@ -34,7 +34,7 @@ are drawn from the [Incubation Entry Considerations][entry].
 
 <!-- lifecycle:contributor-count -->
 - [ ] **Active contributors** — multiple non-maintainer contributors with merged PRs
-  - Current: 1 primary contributor
+  - Current: 1 external contributor with a merged PR (#97), alongside 1 maintainer
 <!-- /lifecycle:contributor-count -->
 
 - [ ] **TAC sponsors** — at least 2 sponsors from different organizations willing to champion the proposal
@@ -60,8 +60,9 @@ are drawn from the [Incubation Entry Considerations][entry].
 ### Technical Maturity
 
 <!-- lifecycle:release-count -->
-- [x] **At least one release** — published artifacts exist
-  - Current: 2 crate releases (cpoe-jitter v0.2.1, cpoe-protocol v0.1.1)
+- [ ] **At least one release** — published artifacts exist
+  - Current: none. Two git tags (`cpop-jitter-v0.2.1`, `cpop-protocol-v0.1.1`) point at a
+    single commit; no crate of either name is published, and there are no GitHub Releases
 <!-- /lifecycle:release-count -->
 
 - [x] **CI/CD pipeline** — automated build, test, and release ([6 workflows](.github/workflows/))
@@ -115,14 +116,15 @@ the TAC during annual reviews.
 
 <!-- lifecycle:yearly-releases -->
 - [ ] **Minimum 2 releases per year**
-  - Current: 2 total releases
+  - Current: no published releases
 <!-- /lifecycle:yearly-releases -->
 
 - [ ] Packaging score SHOULD = 10 (OpenSSF)
 
 ### Testing
 
-- [x] CI tests exist (Rust test suite, CDDL validation, link checking)
+- [x] CI tests exist (CDDL validation, link checking)
+- [ ] Rust test suite runs in CI — the crates under `impl/` are not built or tested by any workflow
 - [ ] Comprehensive unit and integration test suites with documented coverage
 - [ ] CI test score SHOULD = 10 (OpenSSF)
 
@@ -179,7 +181,6 @@ proposal to the TAC, following the same process as Incubation entry.
 
 | Date | Event |
 | ---- | ----- |
-| 2024-12 | Repository created as LF Decentralized Trust lab |
-| 2025-02 | First IETF Internet-Draft submitted (draft-condrey-cpoe-protocol-00) |
-| 2025-06 | First crate releases (cpoe-jitter v0.1.0, cpoe-protocol v0.1.0) |
+| 2026-02 | First IETF Internet-Drafts submitted (draft-condrey-rats-pop-protocol-00, -appraisal-00) |
+| 2026-03 | Repository created as LF Decentralized Trust lab |
 | 2026-03 | GOVERNANCE.md added; lifecycle tracking started |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,10 +6,20 @@
 
 CPoE (Cryptographic Proof of Effort) is an **LF Decentralized Trust lab** with two **IETF individual Internet-Drafts** (not yet adopted by any working group):
 
-- `draft-condrey-cpoe-protocol-00` -- Architecture and Evidence Format (category: experimental)
-- `draft-condrey-cpoe-appraisal-00` -- Forensic Appraisal and Security Model (category: experimental)
+- `draft-condrey-rats-pop-protocol-06` -- Architecture and Evidence Format (category: experimental)
+- `draft-condrey-rats-pop-appraisal-04` -- Forensic Appraisal and Security Model (category: experimental)
+
+The drafts are published on the IETF datatracker under the earlier Proof of Process (PoP)
+series name, while the `docname` in this repository's sources is `draft-condrey-cpoe-*`.
+The two do not currently match. Because the publish workflow submits on any `draft-*` tag,
+resolving this is a prerequisite to the next submission: publishing under the `cpoe` name
+starts a new `-00` series rather than continuing the existing revision history.
 
 Both are independent submissions to the IETF under the Security area, aligned with the RATS (Remote Attestation Procedures) architecture defined in RFC 9334.
+
+Three further draft sources in this repository -- `draft-condrey-cpoe-anchoring`,
+`draft-condrey-cpoe-usecases`, and `draft-condrey-hat` -- have not been submitted and do
+not yet appear on the datatracker.
 
 The repository contains the formal CDDL schema, architecture documentation, and integration proposals for three ecosystems. A reference implementation is maintained separately.
 


### PR DESCRIPTION
The lead change is that **At least one release** flips from `[x]` to `[ ]`, which moves the stated Incubation posture. The evidence line claimed "2 crate releases (cpoe-jitter v0.2.1, cpoe-protocol v0.1.1)". Neither crate is published: the crates.io sparse index returns 404 for `cpoe-jitter`, `cpoe-protocol`, `cpop-jitter`, `cpop-protocol` in both hyphen and underscore forms (method validated against `serde` and `c2pa`, which return 200). There are 0 GitHub Releases here and 0 in `proof-of-process`. The only artifacts are two git tags, `cpop-jitter-v0.2.1` and `cpop-protocol-v0.1.1`, which both point at the same 2026-03-17 commit, and no crate of either name exists in the tree — the manifests under `impl/` are `posme`, `posme-ref`, and `posme-mixing`. The yearly-release line is corrected the same way.

The Status History dates were off by roughly a year. The repo was created 2026-03-15 (API `created_at` and the first commit agree), not 2024-12. The first drafts were submitted 2026-02-06/07, not 2025-02, and the crate-release row has nothing to correct it to, so it goes.

The draft names in both files did not match the live series. The datatracker has `draft-condrey-rats-pop-protocol` at rev 06 and `draft-condrey-rats-pop-appraisal` at rev 04; ROADMAP.md claimed both were `draft-condrey-cpoe-*-00`. Worth a look independently of this PR: all five draft sources declare `docname: draft-condrey-cpoe-*-latest`, and publish.yml submits to the datatracker on any `draft-*` tag, so a tag today opens a new `-00` series instead of continuing six revisions of review history. I described the mismatch in ROADMAP.md rather than changing any `docname`, since which way to resolve it is a maintainer call.

ROADMAP described the project as having two Internet-Drafts, which is right for submitted drafts but omits that the repo carries five draft sources; the other three (`anchoring`, `usecases`, `hat`) are not on the datatracker. That is now stated explicitly.

The Testing line claimed a Rust test suite in CI. `cargo` appears in the workflows only as `cargo install cddl`; nothing builds or tests the `impl/` crates. CDDL validation and link checking are real, so that item is split rather than dropped.

Contributor count corrected from "1 primary contributor" to name the one external contributor with a merged PR, `christianrp45` via #97. The `/contributors` API also lists `ryjones`, but that is a single commit — Ry Jones's `Initial commit.` creating the lab — so it is LFDT onboarding rather than a community contribution. The checkbox stays unticked, and correctly so: "multiple non-maintainer contributors" is not met at one.

Not changed here, flagging instead: PoP slides are posted and Active on the datatracker for `interim-2026-rats-01`, while ROADMAP still has `[ ] Present at IETF RATS WG` unticked, so reality may be ahead of the doc on that line.
