### PR TITLE
chore: ignore local working notes in-repo, not just via global excludes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ report.xml
 /target
 Cargo.lock
 ekr-*
+todo.md
+CLAUDE.md
 draft-condrey-cfrg-*
 docs/posme-*
 docs/NSF_*


### PR DESCRIPTION
`todo.md` and `CLAUDE.md` are kept out of the repo only by a maintainer's personal global excludes file (`~/.config/git/ignore`), so nothing in the repository itself prevents them from being committed. Any other clone, a fresh machine, or a contributor picks up no protection at all. This adds both to `.gitignore` so the rule travels with the repo. Verified with `git -c core.excludesfile=/dev/null check-ignore -v`, which now matches all three local-note patterns from `.gitignore` alone.

`ekr-meeting.md` was already covered by the existing `ekr-*` rule and has never been committed (`git log --all -- ekr-meeting.md` is empty). No change needed for it.

Worth knowing, and not addressed here: `todo.md` was tracked once. It was added in 1e25ccd and untracked again in a370282, and both commits are reachable from `origin/main`, so its contents remain readable in the public history. It is a resolved internal audit list rather than anything credential-bearing; the only match for secret-shaped patterns is the title of finding M-022, "Redundant GITHUB_TOKEN injection". Scrubbing it would mean rewriting published history on a public repo with 5 forks and force-pushing a protected branch, which is a call for you and LFDT rather than something to fold into a chore PR.
