### PR TITLE
ci: correct stale checkout version comments and allow manual link check

### DIFF
--- a/.github/workflows/cddl.yml
+++ b/.github/workflows/cddl.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: "Checkout"
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: "Install Rust"
       uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -30,7 +30,7 @@ jobs:
       pull-requests: write
     steps:
     - name: "Checkout"
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: "Setup"
       id: setup

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -12,6 +12,7 @@ on:
     - "docs/**"
   schedule:
   - cron: "0 3 * * 1"  # Weekly Monday 3am UTC
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -27,7 +28,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: "Checkout"
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: "Check Links"
       uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: "Checkout"
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         # Needed for tracing file history for replacement status
         fetch-depth: 0

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -31,7 +31,7 @@ jobs:
       contents: write
     steps:
     - name: "Checkout"
-      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: "Update Generated Files"
       uses: martinthomson/i-d-template@d2ce969b54014edf5671856b6866866c258bf8f5 # v1


### PR DESCRIPTION
After #106, `actions/checkout` is pinned to `3d3c42e5aac5ba805825da76410c181273ba90b1` everywhere, but the trailing comment reads `# v6` in five workflows and `# v7.0.1` in scorecard.yml. That SHA is v7.0.1, confirmed against `repos/actions/checkout/commits/v7.0.1`. Dependabot only rewrites the comment where it matches its own tracked version, so the stale ones carried through both the v6 to v7.0.0 bump and this one.

The comment is the only human-readable part of a SHA pin. Five of six saying v6 next to a v7.0.1 SHA is misleading in exactly the situation pinning exists to protect, which is someone reviewing what a workflow actually runs. All six now read `# v7.0.1`.

Separately, links.yml gains `workflow_dispatch`. #104 bumped lychee-action from 2.8.0 to 2.9.0, and because the workflow only triggers on `**.md` and `docs/**` paths, that bump merged without the action ever running. There was no way to exercise it on demand. scorecard.yml and publish.yml already expose `workflow_dispatch`, so links.yml was the outlier.

All six workflow files parse under `yaml.safe_load`.
