### PR TITLE
docs: add IETF 127 BoF proposal and supporting material

### DIFF
--- a/docs/ietf127-bof-proposal.md
+++ b/docs/ietf127-bof-proposal.md
@@ -1,0 +1,234 @@
+# Name: Cryptographic Proof of Effort for Content Creation (CPOE)
+
+## Description
+
+Digital signatures establish control of a signing key. Trusted timestamps
+establish that data existed no later than a point in time. Content provenance
+systems record assertions about the origin and handling of an artifact. None of
+these mechanisms provides an interoperable account of the process by which
+digital content was created: how an artifact evolved, which contributions were
+entered by a person, which were inserted or transformed by a tool, and which
+claims about that process can be independently appraised.
+
+This gap matters where a relying party needs evidence about a creation process
+rather than an inference from finished content. Candidate use cases include
+voluntary disclosure of AI-assisted contributions, editorial and publishing
+workflows, academic submissions, and contractual attribution in creative work.
+Today, implementations use vendor-specific event records, scoring methods, and
+trust assumptions. Those artifacts are not portable between authoring tools,
+verifiers, and relying parties, and their privacy and security properties are
+difficult to compare.
+
+The proposed BoF will determine whether the IETF should undertake work on a
+vendor-neutral architecture and interoperable formats for content-process
+evidence and appraisal results. It will examine:
+
+* a common problem statement, terminology, and set of use cases;
+* the threat model for evidence produced on a device controlled by the claimant;
+* the minimum semantics needed for independently verifiable event chains,
+  external contributions, temporal or witness anchors, and appraisal results;
+* data minimization, consent, accessibility, unlinkability, retention, and
+  protection of behavioral data;
+* resource-use and device-autonomy requirements, including whether useful
+  assurance can be provided without mandatory continuous computation or loss of
+  user control;
+* the relationship to RATS, EAT, EAR, CBOR, COSE, trusted timestamping, and
+  content-provenance systems; and
+* evidence of interest from implementers, prospective relying parties,
+  researchers, and reviewers with relevant security, privacy, human-computer
+  interaction, and accessibility expertise.
+
+The BoF is not being asked to endorse the current CPoE proposal as a complete
+solution. In particular, it will not assume that behavioral telemetry proves
+identity or cognition, that a binary human-versus-AI judgment is possible, or
+that a particular sequential-work construction, hardware trust anchor,
+behavioral model, or scoring policy should be mandatory.
+
+The BoF will be successful if it produces clear answers to the following
+questions:
+
+1. Is there a well-scoped interoperability problem that is appropriate for the
+   IETF?
+2. Are the security, privacy, accessibility, energy-use, and device-autonomy
+   constraints understood well enough to define useful work?
+3. Are multiple independent participants willing to author, review, implement,
+   and deploy the resulting specifications?
+4. Should the work proceed in an existing WG, in a new WG, through further
+   non-WG discussion or research, or not in the IETF?
+
+## Required Details
+
+* Status: not WG forming
+* Responsible AD: Christopher Inacio (requested; confirmation pending)
+* BOF proponents: David Condrey <david@writerslogic.com>, WritersLogic Inc.
+* BOF chairs: Scott Perry, Digital Governance Institute (proposed; confirmation
+  pending); Kathleen Moriarty <Kathleen.Moriarty.ietf@gmail.com>, Center for
+  Internet Security (proposed; confirmation pending)
+* Number of people expected to attend: 75
+* Length of session (1 or usually 2 hours): 2 hours
+* Conflicts (whole Areas and/or WGs): RATS, COSE, SPICE, AIPREF, VCON,
+  SECDISPATCH, DISPATCH, and SAAG
+* Chair Conflicts: RATS (Kathleen Moriarty)
+* Technology Overlap: RATS, EAT, EAR, CBOR, COSE, content provenance, creator
+  assertions, trusted timestamping, transparency logs, and Verifiable
+  Credentials
+* Key Participant Conflict: RATS, COSE, SPICE, AIPREF, VCON, and SAAG
+
+## Information for IAB/IESG
+
+To allow evaluation of this proposal, the following summarizes existing work
+and the anticipated standards gap:
+
+* **Any protocols or practices that already exist in this space:**
+  * The RATS architecture (RFC 9334) defines Attesters, Verifiers, Relying
+    Parties, Evidence, and Attestation Results. EAT (RFC 9711) defines a token
+    format for attestation claims, and the RATS WG is developing EAR for
+    attestation results. The present RATS charter is centered on evidence about
+    system components. It does not directly define a content-creation event
+    model or determine which claims can safely be made when the claimant
+    controls the Attesting Environment.
+  * CBOR (RFC 8949), CDDL (RFC 8610), and COSE (RFC 9052) provide encoding,
+    schema, and cryptographic building blocks, but do not define process-evidence
+    semantics.
+  * Trusted timestamping (RFC 3161), transparency logs, and epoch markers can
+    establish existence or freshness relative to an external service. They do
+    not describe how content evolved between anchors.
+  * C2PA Content Credentials and related creator-identity work provide artifact
+    provenance and signed assertions. A process-evidence format could be carried
+    by or referenced from those systems, but is not currently standardized by
+    them. The Content Authenticity Initiative maintains open-source Rust,
+    JavaScript, Python, C/C++, Node.js, and mobile SDKs that could provide the
+    manifest, signing, embedding, and validation layer for such an integration.
+  * SLSA and in-toto define practices and attestation formats for software-build
+    provenance. Their producer/consumer model, signed predicates, and explicit
+    assurance levels are useful prior art, but they do not describe human
+    content-creation events or appraisal of those events.
+  * The Berkeley Protocol on Digital Open Source Investigations defines minimum
+    professional practices for identifying, collecting, preserving, verifying,
+    and analyzing digital open-source information. It is not an Internet wire
+    protocol or a creation-evidence format, but it is relevant relying-party
+    practice for preservation, chain of custody, verification, and ethical use
+    of digital evidence.
+  * Authoring platforms maintain revision histories, audit logs, and tool
+    interaction records. These are generally application-specific and do not
+    share portable evidence or appraisal semantics.
+  * Commercial and experimental systems perform post-hoc AI-text detection or
+    collect behavioral composition data. These systems do not share an
+    interoperable evidence format, security model, or privacy profile.
+* **Which modifications to existing protocols or practices are required:** The
+  BoF should determine whether process attestation can be expressed as a RATS
+  profile or requires an explicit augmentation to the RATS architecture.
+  Possible work includes process-evidence claims or media types, mappings to EAT
+  and EAR, and conventions for carrying or referencing evidence in existing
+  content-provenance systems. CBOR, CDDL, and COSE are expected to be reused
+  unless concrete interoperability gaps are identified.
+* **Which entirely new protocols or practices are required:** Candidate work,
+  subject to BoF consensus, includes a solution-independent information model
+  for content-creation events and contribution provenance; a portable,
+  cryptographically verifiable evidence-chain format; a contribution-receipt
+  format for tool-generated or transformed content; optional external freshness,
+  timestamp, or witness profiles; and an appraisal-result format that states the
+  trust boundary, validation performed, policy used, and limitations. The work
+  should not standardize a universal human-authorship score, a normative
+  behavioral classifier, institutional enforcement policy, or a requirement
+  that users surrender control of their devices.
+* **Open source projects implementing this work:**
+  * The
+    [LF Decentralized Trust Proof of Effort Lab](https://github.com/LF-Decentralized-Trust-labs/proof-of-effort)
+    contains editor's copies of the CPoE specifications, CDDL schemas,
+    diagnostic examples, integration documents, and a minimal implementation
+    of the sequential-memory component. It is not yet a complete,
+    independently interoperable implementation.
+  * [WritersProof](https://writerslogic.com/about/) is a browser and desktop
+    implementation that captures writing-process events and can export `.cpoe`
+    evidence packages; a standalone web verifier is available at
+    <https://verify.writersproof.com/>. WritersLogic states that the underlying
+    protocol and reference implementation are Apache-2.0 licensed. WritersProof
+    is controlled by the same organization as the BoF proponent, and a direct
+    public source-code URL for the application should be supplied before the
+    BoF request is submitted.
+  * Independently developed open-source projects demonstrate overlapping
+    requirements without claiming CPoE compatibility.
+    [KeyWitness](https://github.com/magicseth/keywitness), distributed as the
+    typed.by iOS keyboard, captures per-keystroke timing, touch geometry, and
+    force and seals the typed text as an Ed25519-signed W3C Verifiable
+    Credential using `eddsa-jcs-2022` and `did:key`; its README declares MIT,
+    though no license file is present. It has no trusted timestamp or
+    transparency log, which is one of the layers CPoE specifies. The
+    [Tracked Writing File Format (TWFF)](https://github.com/Functional-Intelligence-Research-Lab/twff)
+    includes an Apache-2.0 container specification, schemas, validators, and the
+    Glass Box reference editor for deterministic writing-process logs.
+    [Proof SDK](https://github.com/EveryInc/proof-sdk) is an MIT-licensed
+    collaborative editor and provenance model that tracks human and agent
+    contributions. [humanshipd](https://github.com/Flagrare/humanshipd) is an
+    early MIT-licensed Rust proof of concept for local capture, signed process
+    records, RFC 3161 anchoring, and offline verification.
+    [Certified Human-Made](https://github.com/dabhunt/krita-certified-human-made)
+    is a GPL-3.0 Krita plug-in that records strokes, layers, timing, and tool use
+    and generates verifiable process certificates.
+    [OpenFab](https://github.com/open-fab-ai/openfab) is an Apache-2.0 software
+    provenance system that records AI/human attribution and signed in-toto/SLSA
+    attestations.
+  * Reusable open-source infrastructure includes the
+    [CAI C2PA SDKs](https://opensource.contentauthenticity.org/docs/introduction/),
+    the [SLSA framework and tooling](https://slsa.dev/), and Cisco's
+    [Model Provenance Kit](https://github.com/cisco-ai-defense/model-provenance-kit).
+    These implement complementary artifact, build, or model-lineage mechanisms,
+    not CPoE process-evidence semantics.
+  * No independent implementation of the CPoE wire formats has yet been
+    confirmed. [Genotone](https://genotone.com/) describes an independently
+    developed internal prototype for C2PA-based audio provenance and open
+    verification, but no publicly licensed source implementation was identified
+    as of 2026-09-01; it is therefore related implementation evidence, not an
+    open-source CPoE implementation.
+
+## Agenda
+
+* 5 minutes: Administrivia, goals, and decision questions — proposed chairs and
+  responsible AD (5/120)
+* 15 minutes: Problem statement and concrete interoperability use cases — David
+  Condrey; draft-condrey-cpoe-usecases (20/120)
+* 15 minutes: Prior IETF discussion and proposed scope and non-goals — David
+  Condrey and proposed chairs; draft-condrey-cpoe-protocol (35/120)
+* 20 minutes: Adversarial analysis and technical feasibility — invited
+  independent security reviewer; draft-condrey-cpoe-protocol and
+  draft-condrey-cpoe-appraisal (55/120)
+* 15 minutes: Privacy, accessibility, energy use, and device autonomy — invited
+  privacy, accessibility, and human-computer interaction reviewers (70/120)
+* 15 minutes: Existing standards, gaps, and possible work items — invited RATS,
+  CAWG/C2PA, and W3C Verifiable Credentials participants (85/120)
+* 20 minutes: Implementation, deployment, and research commitments — short
+  statements from confirmed independent participants, followed by open
+  discussion (105/120)
+* 15 minutes: BoF questions, consensus assessment, and next steps — proposed
+  chairs and responsible AD (120/120)
+
+The chairs should publish the exact consensus questions before the session. The
+agenda intentionally reserves substantial time for critical review and the BoF
+decision rather than solution presentations.
+
+## Links to the mailing list, draft charter if any (for WG-forming BoF), relevant Internet-Drafts, etc.
+
+* Mailing List: Proposed `cpoe@ietf.org`; creation request will be made before
+  submission. Prior discussion is archived on
+  [SECDISPATCH](https://mailarchive.ietf.org/arch/browse/secdispatch/) and
+  [RATS](https://mailarchive.ietf.org/arch/browse/rats/).
+* Draft charter: N/A (not WG forming)
+* Relevant Internet-Drafts:
+  * Use Cases:
+    * [Cryptographic Proof of Effort: Use Cases and Deployment Considerations](https://lf-decentralized-trust-labs.github.io/proof-of-effort/draft-condrey-cpoe-usecases.html)
+  * Proposed Solutions:
+    * [Architecture and Evidence Format — current editor's copy](https://lf-decentralized-trust-labs.github.io/proof-of-effort/draft-condrey-cpoe-protocol.html)
+    * [Forensic Appraisal and Security Model — current editor's copy](https://lf-decentralized-trust-labs.github.io/proof-of-effort/draft-condrey-cpoe-appraisal.html)
+    * [Temporal Anchoring Extensions — current editor's copy](https://lf-decentralized-trust-labs.github.io/proof-of-effort/draft-condrey-cpoe-anchoring.html)
+  * Datatracker versions under the earlier Proof of Process name:
+    * [Architecture and Evidence Format](https://datatracker.ietf.org/doc/draft-condrey-rats-pop-protocol/)
+    * [Forensic Appraisal and Security Model](https://datatracker.ietf.org/doc/draft-condrey-rats-pop-appraisal/)
+* Open-source repository and issue tracker:
+  * <https://github.com/LF-Decentralized-Trust-labs/proof-of-effort>
+  * <https://github.com/LF-Decentralized-Trust-labs/proof-of-effort/issues>
+* Prior IETF consideration:
+  * [IETF 125 joint DISPATCH/SECDISPATCH minutes](https://datatracker.ietf.org/meeting/125/materials/minutes-125-dispatch-202603160100-01)
+  * [IETF 125 RATS minutes](https://datatracker.ietf.org/meeting/125/materials/minutes-125-rats-202603180100-00)
+* IPR:
+  * [Related IPR disclosure 7168](https://datatracker.ietf.org/ipr/7168/)

--- a/docs/ietf127-bof-submission-checklist.md
+++ b/docs/ietf127-bof-submission-checklist.md
@@ -1,0 +1,69 @@
+# IETF 127 CPOE BoF Submission Checklist
+
+This checklist tracks external confirmations and process work that cannot be
+completed by editing the BoF proposal itself. The text intended for the
+Datatracker is in [ietf127-bof-proposal.md](ietf127-bof-proposal.md).
+
+## Leadership and Participants
+
+* [ ] Ask Christopher Inacio to serve as responsible AD or identify the
+  appropriate Security AD.
+* [ ] Ask Scott Perry to co-chair the BoF.
+* [ ] Ask Kathleen Moriarty to co-chair the BoF.
+* [ ] After acceptance, confirm each chair's affiliation, preferred email
+  address, availability for IETF 127, and scheduling conflicts.
+* [ ] Recruit at least two independent proponents from different organizations.
+* [ ] Recruit independent security, privacy, accessibility, and human-computer
+  interaction reviewers.
+* [ ] Confirm speakers for the security review, privacy/accessibility review,
+  standards-gap discussion, and implementation-interest portions of the agenda.
+* [ ] Obtain explicit statements of intent from multiple implementers or
+  prospective relying parties. Do not describe general ecosystem interest as a
+  deployment commitment.
+* [x] Invite maintainers of TWFF/Glass Box, Proof SDK, humanshipd, Certified
+  Human-Made, and OpenFab to review the problem statement and state whether they
+  would participate in interoperability work. Invitations:
+  [TWFF](https://github.com/Functional-Intelligence-Research-Lab/twff/issues/3),
+  [Proof SDK](https://github.com/EveryInc/proof-sdk/issues/79),
+  [humanshipd](https://github.com/Flagrare/humanshipd/issues/1),
+  [Certified Human-Made](https://github.com/dabhunt/krita-certified-human-made/issues/1),
+  and [OpenFab](https://github.com/Open-fab-ai/openfab/issues/41).
+* [x] Invite Khepri Proof of Effort to provide independent process-evidence
+  input and participate in the BoF:
+  <https://github.com/SeekingProof/Proof-of-Effort-/issues/1>.
+* [x] Ask Genotone whether it will publish its specification or verifier source
+  and whether an independent representative will participate in the BoF:
+  <https://github.com/melchior404/genotone/issues/1>.
+
+## Public Discussion
+
+* [ ] Request the dedicated `cpoe@ietf.org` public mailing list, or agree on a
+  different list name with the responsible AD.
+* [ ] Post a call for participation to the dedicated list, SECDISPATCH, RATS,
+  and appropriate content-provenance communities.
+* [ ] Conduct at least one public virtual meeting before submission and publish
+  its notes, participant list, objections, and proposed resolutions.
+* [ ] Ask potential attendees to state whether they intend to author, review,
+  implement, deploy, or otherwise contribute to the work.
+
+## Proposal and Specifications
+
+* [ ] Confirm with the responsible AD that the request should remain
+  non-WG-forming.
+* [ ] Resolve the PoP-to-CPoE draft-name transition and ensure every proposal
+  link identifies the same technical revision.
+* [ ] Reconcile public implementation claims with the current code and test
+  status.
+* [ ] Publish and link the WritersProof application source and license if it is
+  to be counted as an open-source implementation; the current public link points
+  to the WritersLogic organization rather than a source repository.
+* [ ] Include the existing IPR disclosure in outreach material.
+* [ ] Update the proposal with confirmed proponents, chairs, speakers,
+  participation commitments, mailing list, and final scheduling conflicts.
+
+## Deadlines
+
+* [ ] Submit the initial BoF request by **2026-09-18**.
+* [ ] Submit revisions requested by the Area Directors by **2026-10-02**.
+* [ ] Submit refreshed Internet-Drafts before the IETF 127 I-D cutoff on
+  **2026-11-02**.

--- a/docs/ietf127-open-source-landscape.md
+++ b/docs/ietf127-open-source-landscape.md
@@ -1,0 +1,96 @@
+# IETF 127 CPOE Implementation Landscape
+
+Research date: 2026-09-01
+
+This note distinguishes implementations of the proposed CPoE wire formats from
+projects that address adjacent provenance or process-evidence problems. A public
+product, an open standard, and an open-source implementation are not treated as
+synonyms. Repository and license claims below should be rechecked immediately
+before the BoF request is submitted.
+
+## Direct CPoE Work
+
+| Project | Public evidence | Assessment |
+| --- | --- | --- |
+| [LF Decentralized Trust Proof of Effort Lab](https://github.com/LF-Decentralized-Trust-labs/proof-of-effort) | CPoE Internet-Draft sources, CDDL, examples, integration documents, and a minimal sequential-memory implementation | Primary specification repository and proponent-controlled reference work; not a complete independent implementation |
+| [WritersProof](https://writerslogic.com/about/) | Public browser extension, desktop integration, `.cpoe` export, and [web verifier](https://verify.writersproof.com/); WritersLogic states that the protocol/reference implementation is Apache-2.0 | A direct implementation, but controlled by the proponent. The public GitHub link currently identifies the WritersLogic organization rather than the application's source repository, so the application source and license should be linked before submission |
+
+No independently controlled implementation of the CPoE wire formats was found.
+
+## Independent Process-Evidence and Attribution Projects
+
+| Project | License/status | Relevant capability | CPoE relationship |
+| --- | --- | --- | --- |
+| [Tracked Writing File Format (TWFF)](https://github.com/Functional-Intelligence-Research-Lab/twff) | Apache-2.0; specification, schemas, validators, and Python Glass Box reference editor | ZIP container holding a document and deterministic log of AI interactions, paste events, revisions, and timing | Strong independent evidence of the same writing-process interoperability problem; no claimed CPoE support |
+| [KeyWitness / typed.by](https://github.com/magicseth/keywitness) | README declares MIT, but the repository has no LICENSE file and GitHub reports no license; working TypeScript and Swift implementation with a live JSON-LD context at `keywitness.io/ns/v1` | iOS custom keyboard that captures per-keystroke timing, touch coordinates, contact radius, and force, hashes them, and seals the typed text as a W3C VC 2.0 credential signed with Ed25519 (`eddsa-jcs-2022`, `did:key`), with an Apple App Attest assertion and optional Face ID signature | The closest independent work to CPoE found so far, and the only one already building on W3C VC, Data Integrity, JCS, and EAT, with C2PA embedding on its roadmap. It has no trusted timestamp or transparency log, so time is self-asserted inside the signed credential; its own tracker records the Secure Enclave claim as false and the device and biometric bindings as forgeable. No claimed CPoE support |
+| [Proof SDK](https://github.com/EveryInc/proof-sdk) | MIT; working TypeScript editor/server/SDK | Collaborative document editing with provenance tracking for human and agent contributions | Strong authoring and contribution-provenance use case; not a cryptographic CPoE implementation |
+| [humanshipd](https://github.com/Flagrare/humanshipd) | MIT; early Rust proof of concept | Metadata-only writing record, signing, RFC 3161 anchoring, CLI verification, and planned capture adapters | Close technical overlap and an explicit threat model; its own schema and no claimed CPoE support |
+| [Certified Human-Made](https://github.com/dabhunt/krita-certified-human-made) | Repository states GPL-3.0; Python/Rust Krita plug-in | Records strokes, layers, timing, imports, and tool use and produces process certificates | Demonstrates the problem outside text; no claimed CPoE support |
+| [OpenFab](https://github.com/open-fab-ai/openfab) | Apache-2.0; active Rust implementation | Human/AI attribution for software, signed in-toto/SLSA provenance, and human approval gates | Adjacent software-creation domain; useful source of requirements and participants, not CPoE |
+| [Art Provenance Vault](https://github.com/0thernes/art-provenance-vault) | MIT; Python proof of concept | Hash-to-manifest-to-git provenance loop for AI-assisted art | Working basic provenance loop, but signatures, watermarking, and C2PA serialization remain planned; not CPoE |
+| [ScholarScribe](https://github.com/waleedmandour/scholarscribe) | MIT; Rust/Svelte desktop application | Local timestamped writing snapshots exported as JSON | Useful user need, but no cryptographic tamper evidence or CPoE support identified |
+
+## Reusable Open-Source Provenance Infrastructure
+
+| Project | What it supplies | Relevance and limit |
+| --- | --- | --- |
+| [Content Authenticity Initiative SDKs](https://opensource.contentauthenticity.org/docs/introduction/) | Rust, JavaScript, Python, C/C++, Node.js, and mobile implementations for C2PA manifests, signing, embedding, parsing, and validation | A likely carriage and verification layer; C2PA does not define CPoE's content-creation event or appraisal semantics |
+| [SLSA](https://slsa.dev/) and in-toto | Software-build provenance predicates, attestations, producer/consumer roles, and assurance levels | Valuable architecture and terminology for verifiable processes; scoped to software supply chains rather than human content creation |
+| [Cisco Model Provenance Kit](https://github.com/cisco-ai-defense/model-provenance-kit) | Apache-2.0 model-lineage comparison using metadata, tokenizer, and model-weight fingerprints | Demonstrates evidence-based provenance appraisal, but infers model lineage rather than recording a creation process |
+
+## Related Systems Not Counted as Open-Source Implementations
+
+| System | Public evidence | Why it is not counted |
+| --- | --- | --- |
+| [Genotone](https://genotone.com/) | Site describes a working internal C2PA-based audio registration, watermarking, fingerprinting, signing, and verification prototype, with a public registry still planned | No public, licensed source implementation was identified. It is relevant independent prototype evidence, but neither open-source nor CPoE-compatible on current evidence |
+| [Khepri Proof of Effort](https://github.com/SeekingProof/Proof-of-Effort-) | Public documentation describes a LibreOffice/Word process-evidence product and sealed `.poe` artifacts | The public repository contains documentation rather than source code and declares the method patent-pending/all rights reserved |
+| [punchsig](https://github.com/oreparaz/punchsig) | Public firmware and a static HTML verifier for a USB keyboard interposer that Ed25519-signs typed text; two Raspberry Pi Pico boards joined by a unidirectional serial link | The repository carries no LICENSE file, so the source is published rather than open-source. The published firmware also derives its signing key from a hardcoded seed, so current signatures have no unforgeability. It signs only the final typed buffer, with no timing, edit history, timestamp, or replay protection, and references no provenance standard |
+| [NetRise Provenance](https://www.netrise.io/products/provenance) | Commercial product mapping software packages to repositories, maintainers, dependency relationships, and risk signals | No relevant public-source implementation identified; it evaluates software-component origin rather than content-creation effort |
+
+## Relevant Practice and Relying-Party Evidence
+
+punchsig is worth separating from the other uncounted systems because its
+contribution is a trust root rather than a product. It constrains the bytes
+reaching the signer to have crossed a hardware diode from a physical keyboard,
+so a compromised host cannot request a signature over text the user never typed.
+CPoE does not define that boundary and would benefit from a hardware
+human-presence primitive underneath its capture layer. Its author is a
+hardware-security researcher, which makes him a plausible reviewer of the
+appraisal and capture threat model even though the project is not an
+implementation of anything CPoE defines.
+
+The [Berkeley Protocol on Digital Open Source Investigations](https://humanrights.berkeley.edu/projects/developing-the-berkeley-protocol-on-digital-open-source-investigations/)
+is not a software implementation or an IETF protocol. It is important prior
+practice because it establishes minimum professional standards for identifying,
+collecting, preserving, verifying, and analyzing digital open-source evidence.
+Those practices can inform CPoE requirements for preservation, chain of custody,
+validation reporting, minimization, and ethical use.
+
+The banking sector has also articulated a need to trace where information
+originated, how it changed, which model used it, what action followed, and who
+authorized it. The linked
+[International Banker article](https://internationalbanker.com/technology/digital-provenance-the-chain-of-evidence-banks-need-in-the-ai-era/)
+is useful relying-party context, but not implementation evidence. Its scope is
+broader than the current content-creation proposal and should not expand the BoF
+without confirmed financial-sector participants.
+
+## Recommended Outreach Priority
+
+1. KeyWitness/typed.by: an independent implementation that already emits signed
+   W3C Verifiable Credentials over captured keystroke evidence, and whose
+   missing pieces (trusted time, revocation enforcement, binding of device and
+   biometric claims to content) are exactly the layers CPoE specifies.
+2. TWFF/Glass Box and Proof SDK: strongest independent evidence of writing and
+   human/agent contribution-provenance requirements.
+3. humanshipd and Certified Human-Made: closest independent process-capture and
+   appraisal prototypes in text and visual art.
+4. OpenFab: an implementer familiar with portable signed process attestations
+   and human/AI attribution in an adjacent domain.
+5. Genotone: an independent audio-provenance prototype, if its founder will
+   review the scope, publish technical material, or participate in the BoF.
+6. CAI/C2PA, SLSA/in-toto, and Cisco Model Provenance Kit maintainers: reviewers
+   of reuse boundaries rather than claimed CPoE implementers.
+
+For the BoF case, a written statement from even two of these independent teams
+that they share the interoperability problem and intend to participate is more
+valuable than listing many projects without engagement.


### PR DESCRIPTION
Adds the BoF proposal for Cryptographic Proof of Effort for Content Creation (CPOE), along with the submission checklist and a survey of the existing open-source landscape.

- `docs/ietf127-bof-proposal.md` — the proposal itself, framing the gap between signatures, timestamps, and provenance assertions, none of which describe the process by which content was produced
- `docs/ietf127-bof-submission-checklist.md` — submission requirements tracking
- `docs/ietf127-open-source-landscape.md` — prior and adjacent open-source work

Docs only, no code changes.

https://claude.ai/code/session_01UAQmGnfDere6uyNBB2CgiY